### PR TITLE
Rubocop: disable frozen string literal comments

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,7 +1,11 @@
+Style/FrozenStringLiteralComment:
+  EnforcedStyle: never
+
 Metrics/LineLength:
   Max: 130
 
 AllCops:
+  TargetRubyVersion: 2.5
   Exclude:
     - 'Gemfile'
     - 'Gemfile.lock'


### PR DESCRIPTION
set target ruby version to 2.5